### PR TITLE
Fix non-damageable body armor bonding

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,20 @@ All notable changes to Bonded will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.1
+
+### Fixed
+
+- Fixed non-damageable body armor, such as horse armor, being treated as Bonded armor when a tag or datapack included it.
+- Fixed stale Bonded durability data being preserved on items that no longer have valid durability.
+
+## 3.1.1
+
+### Fixed
+
+- Fixed non-damageable body armor, such as horse armor, being treated as Bonded armor when a tag or datapack included it.
+- Fixed stale Bonded durability data being preserved on items that no longer have valid durability.
+
 ## 4.0.0
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -14,10 +14,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 3.1.1
 
+### Added
+
+- 1.21.11: Repair benches can now over-repair gear. Extra repair becomes temporary durability, shown as a pink bar on the item.
+- 1.21.11: Added Scrap, a general repair material for the repair bench. Scrap can appear in chest loot, drop rarely from armored enemies, drop from broken bonded gear, and appear as a byproduct of upgrading gear.
+- 1.21.11: Tool benches and repair benches can now use matching items from adjacent chests and barrels.
+- 1.21.11: Gear found in chest loot or carried by monsters can now start with an innate bond level.
+- 1.21.11: Added config options for innate loot bond.
+- 1.21.11: Added public addon APIs for registering Bonded gear behavior and reading or changing Bonded item stack state.
+- 1.21.11: Added advancements for bonding, upgrading, over-repairing, and finding or using Scrap.
+
+### Changed
+
+- 1.21.11: Backported Bonded 3.1.1.
+- 1.21.11: Item level-ups no longer automatically repair gear. Use over-repairing instead.
+- 1.21.11: The old `API` addon entry point is deprecated. Addons should use `BondedApi`.
+
 ### Fixed
 
 - Fixed non-damageable body armor, such as horse armor, being treated as Bonded armor when a tag or datapack included it.
 - Fixed stale Bonded durability data being preserved on items that no longer have valid durability.
+- 1.21.11: Repair and upgrade addon events now fire from the benches.
 
 ## 4.0.0
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 def minecraftVersion = requiredProp(project, 'project.minecraft')
 def libs = catalogFor(project, minecraftVersion)
-def useKonfig = minecraftVersion != '26.1.2'
+def useKonfig = !['1.21.11', '26.1.2'].contains(minecraftVersion)
 
 dependencies {
     compileOnly library(libs, 'mixin')

--- a/common/src/main/java/com/iamkaf/bonded/leveling/GearManager.java
+++ b/common/src/main/java/com/iamkaf/bonded/leveling/GearManager.java
@@ -62,6 +62,7 @@ public class GearManager {
             items.ifPresent(holders -> {
                 LOGGER.info("Found {} {} [{}]", holders.size(), type.name(), tag.location());
                 holders.stream()
+                        .filter(itemHolder -> type.supports(itemHolder.value().getDefaultInstance()))
                         .forEach(itemHolder -> gearTypeLevelerRegistry.add(itemRegistry.getKey(itemHolder.value()), type));
             });
             if (items.isEmpty()) {

--- a/common/src/main/java/com/iamkaf/bonded/leveling/levelers/ArmorLeveler.java
+++ b/common/src/main/java/com/iamkaf/bonded/leveling/levelers/ArmorLeveler.java
@@ -1,8 +1,13 @@
 package com.iamkaf.bonded.leveling.levelers;
 
 import com.iamkaf.bonded.registry.Tags;
+import com.iamkaf.bonded.util.ItemUtils;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.equipment.Equippable;
 
 public class ArmorLeveler implements GearTypeLeveler {
     @Override
@@ -13,5 +18,17 @@ public class ArmorLeveler implements GearTypeLeveler {
     @Override
     public TagKey<Item> tag() {
         return Tags.ARMORS;
+    }
+
+    @Override
+    public boolean supports(ItemStack gear) {
+        Equippable equippable = gear.get(DataComponents.EQUIPPABLE);
+        if (equippable == null) {
+            return false;
+        }
+
+        EquipmentSlot slot = equippable.slot();
+        return slot.getType() == EquipmentSlot.Type.HUMANOID_ARMOR
+                || (slot == EquipmentSlot.BODY && ItemUtils.hasDamageableMaxDamage(gear));
     }
 }

--- a/common/src/main/java/com/iamkaf/bonded/leveling/levelers/GearTypeLeveler.java
+++ b/common/src/main/java/com/iamkaf/bonded/leveling/levelers/GearTypeLeveler.java
@@ -18,6 +18,10 @@ public interface GearTypeLeveler {
 
     TagKey<Item> tag();
 
+    default boolean supports(ItemStack gear) {
+        return true;
+    }
+
     default int getMaxExperience(ItemStack gear) {
         return TierMap.getExperienceCap(gear.getItem());
     }

--- a/common/src/main/java/com/iamkaf/bonded/registry/GearTypeLevelerRegistry.java
+++ b/common/src/main/java/com/iamkaf/bonded/registry/GearTypeLevelerRegistry.java
@@ -21,7 +21,12 @@ public class GearTypeLevelerRegistry {
             return null;
         }
 
-        return map.get(BuiltInRegistries.ITEM.getKey(gear.getItem()));
+        GearTypeLeveler leveler = map.get(BuiltInRegistries.ITEM.getKey(gear.getItem()));
+        if (leveler == null || !leveler.supports(gear)) {
+            return null;
+        }
+
+        return leveler;
     }
 
     public GearTypeLeveler register(GearTypeLeveler leveler) {

--- a/common/src/main/java/com/iamkaf/bonded/util/MaxDamageModifiers.java
+++ b/common/src/main/java/com/iamkaf/bonded/util/MaxDamageModifiers.java
@@ -105,7 +105,13 @@ public final class MaxDamageModifiers {
 
     public static void rebaseExisting(ItemStack stack, int baseMaxDamage) {
         MaxDamageModifiersComponent component = stack.get(DataComponents.MAX_DAMAGE_MODIFIERS.get());
-        if (component == null || baseMaxDamage <= 0) {
+        if (component == null) {
+            return;
+        }
+
+        if (baseMaxDamage <= 0) {
+            stack.remove(DataComponents.MAX_DAMAGE_MODIFIERS.get());
+            writeMaxDamage(stack, 0);
             return;
         }
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -4,7 +4,8 @@ plugins {
 
 def minecraftVersion = requiredProp(project, 'project.minecraft')
 def libs = catalogFor(project, minecraftVersion)
-def useKonfig = minecraftVersion != '26.1.2'
+def isModernLine = !minecraftVersion.startsWith('1.')
+def useKonfig = !['1.21.11', '26.1.2'].contains(minecraftVersion)
 
 repositories {
     exclusiveContent {
@@ -21,18 +22,32 @@ repositories {
 }
 
 dependencies {
-    compileOnly library(libs, 'amber')
-    implementation library(libs, 'fabric-api')
-    runtimeOnly library(libs, 'modmenu')
-    runtimeOnly library(libs, 'amber-fabric')
-    if (useKonfig) {
-        compileOnly library(libs, 'konfig')
-        runtimeOnly library(libs, 'konfig-fabric')
+    if (isModernLine) {
+        compileOnly library(libs, 'amber')
+        implementation library(libs, 'fabric-api')
+        runtimeOnly library(libs, 'modmenu')
+        runtimeOnly library(libs, 'amber-fabric')
+        if (useKonfig) {
+            compileOnly library(libs, 'konfig')
+            runtimeOnly library(libs, 'konfig-fabric')
+        } else {
+            implementation library(libs, 'forgeconfigapiport-fabric')
+        }
+        if (providers.gradleProperty('bonded.withTeaKit').orElse('false').map { it.toBoolean() }.get()) {
+            runtimeOnly library(libs, 'teakit-fabric')
+        }
     } else {
-        implementation library(libs, 'forgeconfigapiport-fabric')
-    }
-    if (providers.gradleProperty('bonded.withTeaKit').orElse('false').map { it.toBoolean() }.get()) {
-        runtimeOnly library(libs, 'teakit-fabric')
+        modImplementation library(libs, 'fabric-api')
+        modLocalRuntime library(libs, 'fabric-api')
+        modImplementation library(libs, 'amber-fabric')
+        if (useKonfig) {
+            modImplementation library(libs, 'konfig-fabric')
+        } else {
+            modImplementation library(libs, 'forgeconfigapiport-fabric')
+        }
+        if (providers.gradleProperty('bonded.withTeaKit').orElse('false').map { it.toBoolean() }.get()) {
+            modLocalRuntime library(libs, 'teakit-fabric')
+        }
     }
 }
 

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 def minecraftVersion = requiredProp(project, 'project.minecraft')
 def libs = catalogFor(project, minecraftVersion)
-def useKonfig = minecraftVersion != '26.1.2'
+def useKonfig = !['1.21.11', '26.1.2'].contains(minecraftVersion)
 
 dependencies {
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 def minecraftVersion = requiredProp(project, 'project.minecraft')
 def libs = catalogFor(project, minecraftVersion)
-def useKonfig = minecraftVersion != '26.1.2'
+def useKonfig = !['1.21.11', '26.1.2'].contains(minecraftVersion)
 
 repositories {
     exclusiveContent {

--- a/teakit.toml
+++ b/teakit.toml
@@ -21,6 +21,29 @@ configureOnDemand = false
 "teakit.worldId" = "bonded_teakit"
 "teakit.worldName" = "Bonded TeaKit"
 
+[nodes."1.21.11-fabric"]
+loader = "fabric"
+minecraft = "1.21.11"
+tasks = [":fabric:1.21.11:runClient"]
+gameDirectory = "fabric/versions/1.21.11/runs/client"
+
+[nodes."1.21.11-forge"]
+loader = "forge"
+minecraft = "1.21.11"
+tasks = [":forge:1.21.11:runClient"]
+gameDirectory = "forge/versions/1.21.11/run"
+
+[nodes."1.21.11-forge".environment]
+GLFW_PLATFORM = "x11"
+XDG_SESSION_TYPE = "x11"
+WAYLAND_DISPLAY = ""
+
+[nodes."1.21.11-neoforge"]
+loader = "neoforge"
+minecraft = "1.21.11"
+tasks = [":neoforge:1.21.11:runClient"]
+gameDirectory = "neoforge/versions/1.21.11/run"
+
 [nodes."26.1.2-fabric"]
 loader = "fabric"
 minecraft = "26.1.2"

--- a/test/scenarios/bonded/horse-armor-storage.scenario.ts
+++ b/test/scenarios/bonded/horse-armor-storage.scenario.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "@teakit/test";
+import type { ScenarioDefinition } from "@teakit/test";
+
+const horseArmorStorageScenario: ScenarioDefinition = {
+  name: "bonded-horse-armor-storage-stability",
+  setup: [
+    {
+      action: "command",
+      command: "/clear @s"
+    },
+    {
+      action: "command",
+      command: "/tp @s 0 72 0"
+    },
+    {
+      action: "command",
+      command: "/fill -2 70 -2 2 74 2 minecraft:air replace"
+    },
+    {
+      action: "command",
+      command: "/fill -2 70 -2 2 70 2 minecraft:stone replace"
+    },
+    {
+      action: "command",
+      command: "/setblock 0 71 0 minecraft:chest[facing=north]"
+    },
+    {
+      action: "wait_for_block",
+      x: 0,
+      y: 71,
+      z: 0,
+      blockId: "minecraft:chest",
+      timeoutMs: 3000
+    }
+  ],
+  steps: [
+    {
+      action: "command",
+      command: "/item replace block 0 71 0 container.0 with minecraft:golden_horse_armor 1"
+    },
+    {
+      action: "command",
+      command: "/item replace block 0 71 0 container.1 with minecraft:iron_horse_armor 1"
+    },
+    {
+      action: "command",
+      command: "/item replace block 0 71 0 container.2 with minecraft:wolf_armor 1"
+    },
+    {
+      action: "wait_ms",
+      durationMs: 500
+    },
+    {
+      action: "assert_command_success",
+      command: "/data get block 0 71 0 Items",
+      expectOutputContains: [
+        "minecraft:golden_horse_armor",
+        "minecraft:iron_horse_armor",
+        "minecraft:wolf_armor"
+      ]
+    }
+  ],
+  cleanup: [
+    {
+      action: "command",
+      command: "/clear @s"
+    },
+    {
+      action: "command",
+      command: "/fill -2 70 -2 2 74 2 minecraft:air replace"
+    }
+  ]
+};
+
+describe("Bonded horse armor storage", () => {
+  test(horseArmorStorageScenario.name, async ({ scenario }) => {
+    const result = await scenario.run(horseArmorStorageScenario, { timeoutMs: 60_000 });
+
+    expect(result.error ?? null).toBeNull();
+  });
+});

--- a/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/Bonded.java
+++ b/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/Bonded.java
@@ -1,0 +1,59 @@
+package com.iamkaf.bonded;
+
+import com.iamkaf.amber.api.core.v2.AmberInitializer;
+import com.iamkaf.bonded.bonuses.Bonuses;
+import com.iamkaf.bonded.command.BondedCommands;
+import com.iamkaf.bonded.config.BondedCommonConfig;
+import com.iamkaf.bonded.leveling.GameplayHooks;
+import com.iamkaf.bonded.leveling.GearManager;
+import com.iamkaf.bonded.leveling.levelers.Levelers;
+import com.iamkaf.bonded.loot.ScrapDrops;
+import com.iamkaf.bonded.loot.WorldInnateBond;
+import com.iamkaf.bonded.registry.*;
+import com.mojang.logging.LogUtils;
+import net.minecraft.resources.Identifier;
+import net.neoforged.neoforge.common.ModConfigSpec;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+
+public class Bonded {
+    public static final String MOD_ID = "bonded";
+    public static final Logger LOGGER = LogUtils.getLogger();
+    public static final BondedCommonConfig CONFIG;
+    public static final ModConfigSpec CONFIG_SPEC;
+    public static GearManager GEAR = new GearManager();
+
+    static {
+        Pair<BondedCommonConfig, ModConfigSpec> pair =
+                new ModConfigSpec.Builder().configure(BondedCommonConfig::new);
+        CONFIG = pair.getLeft();
+        CONFIG_SPEC = pair.getRight();
+    }
+
+    public static void init() {
+        LOGGER.info("Bonded initializing.");
+
+        AmberInitializer.initialize(MOD_ID);
+
+        // Registries
+        Blocks.init();
+        Items.init();
+        DataComponents.init();
+        CreativeModeTabs.init();
+        BondedCommands.init();
+        GameplayHooks.init();
+        WorldInnateBond.init();
+        ScrapDrops.init();
+        Levelers.init();
+        Bonuses.init();
+        TierMap.init();
+        Sounds.init();
+    }
+
+    /**
+     * Creates resource location in the mod namespace with the given path.
+     */
+    public static Identifier resource(String path) {
+        return Identifier.fromNamespaceAndPath(MOD_ID, path);
+    }
+}

--- a/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/BondedClient.java
+++ b/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/BondedClient.java
@@ -1,0 +1,11 @@
+package com.iamkaf.bonded;
+
+import com.iamkaf.bonded.client.HUD;
+import com.iamkaf.amber.api.event.v1.events.common.client.HudEvents;
+
+public class BondedClient {
+    public static void init() {
+        HUD.init();
+        HudEvents.RENDER_HUD.register(HUD::onRenderHud);
+    }
+}

--- a/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/block/AdjacentBenchStorage.java
+++ b/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/block/AdjacentBenchStorage.java
@@ -1,0 +1,165 @@
+package com.iamkaf.bonded.block;
+
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.function.Predicate;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.particles.ItemParticleOption;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.BarrelBlock;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.ChestBlock;
+import net.minecraft.world.level.block.state.BlockState;
+
+final class AdjacentBenchStorage {
+    private AdjacentBenchStorage() {
+    }
+
+    static boolean has(Level level, BlockPos benchPos, Predicate<ItemStack> predicate) {
+        for (BlockPos storagePos : findStorageBlocks(level, benchPos)) {
+            Container container = getStorageContainer(level, storagePos);
+            if (container == null) {
+                continue;
+            }
+
+            for (int i = 0; i < container.getContainerSize(); i++) {
+                ItemStack stack = container.getItem(i);
+                if (!stack.isEmpty() && predicate.test(stack)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    static Optional<ItemStack> find(Level level, BlockPos benchPos, Predicate<ItemStack> predicate) {
+        for (BlockPos storagePos : findStorageBlocks(level, benchPos)) {
+            Container container = getStorageContainer(level, storagePos);
+            if (container == null) {
+                continue;
+            }
+
+            for (int i = 0; i < container.getContainerSize(); i++) {
+                ItemStack stack = container.getItem(i);
+                if (!stack.isEmpty() && predicate.test(stack)) {
+                    return Optional.of(stack.copyWithCount(1));
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    static Optional<ConsumedStorageItem> consume(Level level, BlockPos benchPos, Predicate<ItemStack> predicate) {
+        for (BlockPos storagePos : findStorageBlocks(level, benchPos)) {
+            Container container = getStorageContainer(level, storagePos);
+            if (container == null) {
+                continue;
+            }
+
+            for (int i = 0; i < container.getContainerSize(); i++) {
+                ItemStack stack = container.getItem(i);
+                if (!stack.isEmpty() && predicate.test(stack)) {
+                    ItemStack consumed = stack.copyWithCount(1);
+                    stack.shrink(1);
+                    container.setChanged();
+                    return Optional.of(new ConsumedStorageItem(storagePos, consumed));
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    static void emitStorageUseParticles(Level level, ConsumedStorageItem consumed) {
+        if (level instanceof ServerLevel serverLevel) {
+            BlockPos pos = consumed.storagePos();
+            serverLevel.sendParticles(
+                    new ItemParticleOption(ParticleTypes.ITEM, consumed.stack()),
+                    pos.getX() + 0.5d,
+                    pos.getY() + 0.8d,
+                    pos.getZ() + 0.5d,
+                    18,
+                    0.25d,
+                    0.25d,
+                    0.25d,
+                    0.05d
+            );
+            serverLevel.sendParticles(
+                    ParticleTypes.HAPPY_VILLAGER,
+                    pos.getX() + 0.5d,
+                    pos.getY() + 1.0d,
+                    pos.getZ() + 0.5d,
+                    8,
+                    0.25d,
+                    0.25d,
+                    0.25d,
+                    0.02d
+            );
+        }
+    }
+
+    private static Set<BlockPos> findStorageBlocks(Level level, BlockPos startPos) {
+        Set<BlockPos> visitedBenches = new HashSet<>();
+        Set<BlockPos> storageBlocks = new LinkedHashSet<>();
+        Queue<BlockPos> benches = new ArrayDeque<>();
+        benches.add(startPos.immutable());
+
+        while (!benches.isEmpty()) {
+            BlockPos benchPos = benches.remove();
+            if (!visitedBenches.add(benchPos)) {
+                continue;
+            }
+
+            for (Direction direction : Direction.values()) {
+                BlockPos adjacentPos = benchPos.relative(direction);
+                BlockState adjacentState = level.getBlockState(adjacentPos);
+
+                if (isBench(adjacentState)) {
+                    benches.add(adjacentPos.immutable());
+                } else if (isEligibleStorage(adjacentState)) {
+                    storageBlocks.add(adjacentPos.immutable());
+                }
+            }
+        }
+
+        return storageBlocks;
+    }
+
+    private static boolean isBench(BlockState state) {
+        Block block = state.getBlock();
+        return block instanceof RepairBenchBlock || block instanceof ToolBenchBlock;
+    }
+
+    private static boolean isEligibleStorage(BlockState state) {
+        Block block = state.getBlock();
+        return block instanceof ChestBlock || block instanceof BarrelBlock;
+    }
+
+    private static Container getStorageContainer(Level level, BlockPos pos) {
+        BlockState state = level.getBlockState(pos);
+        Block block = state.getBlock();
+        if (block instanceof ChestBlock chestBlock) {
+            return ChestBlock.getContainer(chestBlock, state, level, pos, true);
+        }
+
+        if (block instanceof BarrelBlock && level.getBlockEntity(pos) instanceof Container container) {
+            return container;
+        }
+
+        return null;
+    }
+
+    record ConsumedStorageItem(BlockPos storagePos, ItemStack stack) {
+    }
+}

--- a/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/client/HUD.java
+++ b/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/client/HUD.java
@@ -1,0 +1,223 @@
+package com.iamkaf.bonded.client;
+
+import com.iamkaf.bonded.Bonded;
+import com.iamkaf.bonded.block.RepairBenchBlock;
+import com.iamkaf.bonded.block.ToolBenchBlock;
+import com.iamkaf.bonded.leveling.levelers.GearTypeLeveler;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
+import net.minecraft.client.gui.screens.inventory.tooltip.DefaultTooltipPositioner;
+import net.minecraft.client.gui.screens.inventory.tooltip.TooltipRenderUtil;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Repairable;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+
+/**
+ * HUD class responsible for rendering custom HUD elements in the game.
+ */
+public class HUD {
+    public static final int WHITE = 0xffffffff;
+    public static final int OUTLINE_COLOR = 0x00000000;
+    public static boolean enabled = true;
+    private static Minecraft mc;
+
+    /**
+     * Initializes the HUD by getting the Minecraft instance.
+     */
+    public static void init() {
+        mc = Minecraft.getInstance();
+    }
+
+    /**
+     * Renders the HUD elements on the screen.
+     *
+     * @param guiGraphics  The graphics context for rendering the GUI.
+     * @param deltaTracker The delta tracker for tracking changes.
+     */
+    public static void onRenderHud(GuiGraphics guiGraphics, DeltaTracker deltaTracker) {
+        if (mc == null) mc = Minecraft.getInstance();
+
+        if (!shouldRender()) {
+            return;
+        }
+
+        LocalPlayer player = mc.player;
+        assert mc.level != null;
+        assert player != null;
+        BlockHitResult hitResult = raytrace(mc.level, player);
+
+        boolean hasMenuOpen = mc.screen != null;
+
+        if (hitResult.getType() == BlockHitResult.Type.MISS || hasMenuOpen) {
+            return;
+        }
+
+        BlockState block = player.level().getBlockState(hitResult.getBlockPos());
+        int centerX = guiGraphics.guiWidth() / 2;
+        int centerY = guiGraphics.guiHeight() / 2;
+        int xOffset = 15;
+        int yOffset = -5;
+
+        if (block.getBlock() instanceof RepairBenchBlock) {
+            renderRepairBenchInfo(guiGraphics, mc.font, centerX + xOffset, centerY + yOffset, player);
+        } else if (block.getBlock() instanceof ToolBenchBlock) {
+            renderToolBenchInfo(guiGraphics, mc.font, centerX + xOffset, centerY + yOffset, player);
+        }
+    }
+
+    /**
+     * Checks if the HUD should be rendered.
+     *
+     * @return true if the HUD should be rendered, false otherwise.
+     */
+    private static boolean shouldRender() {
+        return !(mc.getDebugOverlay()
+                .showDebugScreen() || mc.options.hideGui || !enabled || mc.level == null || mc.player == null);
+    }
+
+    /**
+     * Renders information about the Repair Bench on the HUD.
+     *
+     * @param guiGraphics  The graphics context for rendering the GUI.
+     * @param textRenderer The font renderer for rendering text.
+     * @param x            The x-coordinate for rendering.
+     * @param y            The y-coordinate for rendering.
+     * @param player       The local player.
+     */
+    private static void renderRepairBenchInfo(GuiGraphics guiGraphics, Font textRenderer, int x, int y, LocalPlayer player) {
+        ItemStack stack = player.getMainHandItem();
+        GearTypeLeveler leveler = Bonded.GEAR.getLeveler(stack);
+        if (leveler == null) return;
+
+        Repairable repairable = stack.get(DataComponents.REPAIRABLE);
+        if (stack.isEmpty() || repairable == null) return;
+        Optional<ItemStack> repairIngredient = RepairBenchBlock.getInventoryRepairIngredientPreview(
+                player.getInventory(),
+                repairable
+        );
+        if (repairIngredient.isEmpty()) return;
+
+        text(
+                guiGraphics,
+                textRenderer,
+                Component.translatable("bonded.hud.repair"),
+                x - 2,
+                y - textRenderer.lineHeight - 4
+        );
+        TooltipRenderUtil.renderTooltipBackground(guiGraphics, x, y, 20, 20, null);
+        guiGraphics.renderItem(repairIngredient.get(), x + 2, y + 2);
+        HUD.renderTooltip(guiGraphics, repairIngredient.get(), x + 16, y + 12);
+        // TODO: guiGraphics.renderItemDecorations()
+    }
+
+    /**
+     * Renders information about the Tool Bench on the HUD.
+     *
+     * @param guiGraphics  The graphics context for rendering the GUI.
+     * @param textRenderer The font renderer for rendering text.
+     * @param x            The x-coordinate for rendering.
+     * @param y            The y-coordinate for rendering.
+     * @param player       The local player.
+     */
+    private static void renderToolBenchInfo(GuiGraphics guiGraphics, Font textRenderer, int x, int y, LocalPlayer player) {
+        ItemStack stack = player.getMainHandItem();
+        GearTypeLeveler leveler = Bonded.GEAR.getLeveler(stack);
+        if (leveler == null) return;
+
+        assert mc.level != null;
+        var lookup = mc.level.holderLookup(Registries.ITEM);
+
+        TagKey<Item> upgradeIngredientTag = leveler.getUpgradeIngredient(stack);
+        assert upgradeIngredientTag != null;
+        Optional<HolderSet.Named<Item>> holders = lookup.get(upgradeIngredientTag);
+        if (holders.isEmpty()) return;
+        ItemStack upgradeIngredient = holders.get().get(0).value().getDefaultInstance();
+
+        Item upgrade = leveler.getUpgrade(stack);
+        if (stack.isEmpty() || upgrade == null) return;
+
+        text(
+                guiGraphics,
+                textRenderer,
+                Component.translatable("bonded.hud.upgrade"),
+                x - 1,
+                y - textRenderer.lineHeight - 4
+        );
+        TooltipRenderUtil.renderTooltipBackground(guiGraphics, x, y, 20, 20, null);
+        guiGraphics.renderItem(upgradeIngredient, x + 2, y + 2);
+        TooltipRenderUtil.renderTooltipBackground(guiGraphics, x + 24 + 4, y, 20, 20, null);
+        guiGraphics.renderItem(upgrade.getDefaultInstance(), x + 24 + 2 + 4, y + 2);
+        HUD.renderTooltip(guiGraphics, stack, x + 44, y + 12);
+    }
+
+    /**
+     * Renders text on the HUD.
+     *
+     * @param context The graphics context for rendering the GUI.
+     * @param font    The font renderer for rendering text.
+     * @param message The message to render.
+     * @param x       The x-coordinate for rendering.
+     * @param y       The y-coordinate for rendering.
+     */
+    private static void text(GuiGraphics context, Font font, Component message, int x, int y) {
+        context.drawString(font, message, x, y, WHITE);
+    }
+
+    /**
+     * Performs a raytrace to determine the block the player is looking at.
+     *
+     * @param level  The level in which the player is located.
+     * @param player The player performing the raytrace.
+     * @return The result of the raytrace.
+     */
+    public static @NotNull BlockHitResult raytrace(Level level, Player player) {
+        Vec3 eyePosition = player.getEyePosition();
+        Vec3 rotation = player.getViewVector(1);
+        double reach = player.getAttributeValue(Attributes.BLOCK_INTERACTION_RANGE);
+        Vec3 combined = eyePosition.add(rotation.x * reach, rotation.y * reach, rotation.z * reach);
+        return level.clip(new ClipContext(eyePosition, combined, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, player));
+    }
+
+    /**
+     * Renders a tooltip for the given item stack at the specified coordinates.
+     *
+     * @param guiGraphics The graphics context for rendering the GUI.
+     * @param stack       The item stack for which to render the tooltip.
+     * @param x           The x-coordinate for rendering the tooltip.
+     * @param y           The y-coordinate for rendering the tooltip.
+     */
+    private static void renderTooltip(GuiGraphics guiGraphics, ItemStack stack, int x, int y) {
+        guiGraphics.renderTooltip(
+                mc.font,
+                Screen.getTooltipFromItem(mc, stack)
+                        .stream()
+                        .map(Component::getVisualOrderText)
+                        .map(ClientTooltipComponent::create)
+                        .toList(),
+                x,
+                y,
+                DefaultTooltipPositioner.INSTANCE,
+                stack.get(DataComponents.TOOLTIP_STYLE)
+        );
+    }
+}

--- a/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/config/BondedCommonConfig.java
+++ b/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/config/BondedCommonConfig.java
@@ -1,0 +1,67 @@
+package com.iamkaf.bonded.config;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public class BondedCommonConfig {
+    public final ModConfigSpec.ConfigValue<Boolean> enableUpgrading;
+    public final ModConfigSpec.ConfigValue<Boolean> enableRepairing;
+    public final ModConfigSpec.ConfigValue<Boolean> enableTooltips;
+    public final ModConfigSpec.ConfigValue<Integer> levelsToUpgrade;
+    public final ModConfigSpec.ConfigValue<Integer> defaultMaxExperienceForUnknownItems;
+    public final ModConfigSpec.ConfigValue<Double> durabilityGainedOnRepairBench;
+    public final ModConfigSpec.ConfigValue<Double> weaponDamageDealtExperienceGainedMultiplier;
+    public final ModConfigSpec.ConfigValue<Double> armorDamageTakenExperienceGainedMultiplier;
+    public final ModConfigSpec.ConfigValue<Integer> experienceForMiningOres;
+    public final ModConfigSpec.ConfigValue<Boolean> sendChatMessages;
+    public final ModConfigSpec.ConfigValue<Boolean> enableInnateLootBond;
+    public final ModConfigSpec.ConfigValue<Integer> innateLootBondMin;
+    public final ModConfigSpec.ConfigValue<Integer> innateLootBondMax;
+    public final ModConfigSpec.ConfigValue<Double> chestScrapChance;
+    public final ModConfigSpec.ConfigValue<Double> armoredEnemyScrapChance;
+    public final ModConfigSpec.ConfigValue<Integer> brokenGearScrapCap;
+
+
+    public BondedCommonConfig(ModConfigSpec.Builder builder) {
+        enableUpgrading =
+                builder.translation("bonded.config.upgrading_enabled").define("upgrading_enabled", true);
+        enableRepairing =
+                builder.translation("bonded.config.repairing_enabled").define("repairing_enabled", true);
+        sendChatMessages =
+                builder.translation("bonded.config.send_chat_messages").define("send_chat_messages", true);
+        enableTooltips =
+                builder.translation("bonded.config.tooltips_enabled").define("tooltips_enabled", true);
+        enableInnateLootBond =
+                builder.translation("bonded.config.innate_loot_bond_enabled").define("innate_loot_bond_enabled", true);
+
+        levelsToUpgrade = builder.translation("bonded.config.levels_to_upgrade")
+                .defineInRange("levels_to_upgrade", 10, 10, 100);
+        defaultMaxExperienceForUnknownItems =
+                builder.translation("bonded.config.default_experience_for_unknown_items")
+                        .define("default_experience_for_unknown_items", 1000);
+
+        durabilityGainedOnRepairBench = builder.translation("bonded.config.durability_gained_on_repair_bench")
+                .defineInRange("durability_gained_on_repair_bench", 0.2d, 0.1d, 1d);
+
+        weaponDamageDealtExperienceGainedMultiplier =
+                builder.translation("bonded.config.weapon_damage_dealt_experience_multiplier")
+                        .defineInRange("weapon_damage_dealt_experience_multiplier", 3d, 1.0d, 20d);
+        armorDamageTakenExperienceGainedMultiplier =
+                builder.translation("bonded.config.armor_damage_taken_experience_multiplier")
+                        .defineInRange("armor_damage_taken_experience_multiplier", 1d, 1.0d, 20d);
+
+        experienceForMiningOres = builder.translation("bonded.config.experience_for_mining_ores")
+                .defineInRange("experience_for_mining_ores", 10, 1, 10);
+
+        innateLootBondMin = builder.translation("bonded.config.innate_loot_bond_min")
+                .defineInRange("innate_loot_bond_min", 500, 0, Integer.MAX_VALUE);
+        innateLootBondMax = builder.translation("bonded.config.innate_loot_bond_max")
+                .defineInRange("innate_loot_bond_max", 999, 0, Integer.MAX_VALUE);
+
+        chestScrapChance = builder.translation("bonded.config.chest_scrap_chance")
+                .defineInRange("chest_scrap_chance", 0.08d, 0.0d, 1.0d);
+        armoredEnemyScrapChance = builder.translation("bonded.config.armored_enemy_scrap_chance")
+                .defineInRange("armored_enemy_scrap_chance", 0.04d, 0.0d, 1.0d);
+        brokenGearScrapCap = builder.translation("bonded.config.broken_gear_scrap_cap")
+                .defineInRange("broken_gear_scrap_cap", 32, 0, Integer.MAX_VALUE);
+    }
+}

--- a/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/leveling/GameplayHooks.java
+++ b/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/leveling/GameplayHooks.java
@@ -1,0 +1,309 @@
+package com.iamkaf.bonded.leveling;
+
+import com.iamkaf.amber.api.event.v1.events.common.BlockEvents;
+import com.iamkaf.amber.api.event.v1.events.common.EntityEvent;
+import com.iamkaf.amber.api.event.v1.events.common.ItemEvents;
+import com.iamkaf.amber.api.event.v1.events.common.PlayerEvents;
+import com.iamkaf.amber.api.functions.v1.ItemFunctions;
+import com.iamkaf.bonded.Bonded;
+import com.iamkaf.bonded.advancement.BondedAdvancements;
+import com.iamkaf.bonded.api.event.BondEvent;
+import com.iamkaf.bonded.api.event.GameEvents;
+import com.iamkaf.bonded.component.ItemLevelContainer;
+import com.iamkaf.bonded.leveling.levelers.GearTypeLeveler;
+import com.iamkaf.bonded.leveling.levelers.MeleeWeaponsLeveler;
+import com.iamkaf.bonded.registry.DataComponents;
+import com.iamkaf.bonded.registry.Sounds;
+import com.iamkaf.bonded.registry.TierMap;
+import com.iamkaf.bonded.util.ItemUtils;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.NonNullList;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.ProjectileWeaponItem;
+import net.minecraft.world.item.enchantment.Repairable;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.List;
+
+import static net.minecraft.core.component.DataComponents.REPAIRABLE;
+
+public class GameplayHooks {
+    public static void init() {
+        BlockEvents.BLOCK_BREAK_AFTER.register((level, player, pos, state, blockEntity) -> {
+            if (player instanceof ServerPlayer serverPlayer) {
+                GameplayHooks.onBlockBreak(level, pos, state, serverPlayer, blockEntity);
+            }
+        });
+
+        GameEvents.AWARD_ITEM_EXPERIENCE.register(GameplayHooks::onGenericItemExperience);
+        PlayerEvents.CRAFT_ITEM.register(GameplayHooks::onItemCrafted);
+        GameEvents.MODIFY_SMITHING_RESULT.register(GameplayHooks::onItemSmithed);
+        ItemEvents.ITEM_PICKUP.register(GameplayHooks::onItemPickedUp);
+        PlayerEvents.SHIELD_BLOCK.register(GameplayHooks::onShieldBlock);
+        EntityEvent.AFTER_DAMAGE.register(GameplayHooks::onEntityHurt);
+        BondEvent.ITEM_LEVELED_UP.register(GameplayHooks::onItemLeveledUp);
+        ItemEvents.MODIFY_DEFAULT_COMPONENTS.register(GameplayHooks::onModifyDefaultComponents);
+    }
+
+    private static void onItemLeveledUp(ItemStack stack, Player player, ItemLevelContainer container, Integer integer) {
+        var itemLevel = stack.get(DataComponents.ITEM_LEVEL_CONTAINER.get()).getLevel();
+        var level = player.level();
+        Integer maxLevel = Bonded.CONFIG.levelsToUpgrade.get();
+        if (player instanceof ServerPlayer serverPlayer) {
+            BondedAdvancements.grant(serverPlayer, BondedAdvancements.FIRST_LEVEL);
+            if (itemLevel == maxLevel) {
+                BondedAdvancements.grant(serverPlayer, BondedAdvancements.MAX_LEVEL);
+            }
+        }
+
+        level.playSound(
+                null,
+                player.getX(),
+                player.getY(),
+                player.getZ(),
+                itemLevel == maxLevel ? Sounds.ITEM_MAX_LEVEL.get() : Sounds.ITEM_LEVEL.get(),
+                SoundSource.PLAYERS
+        );
+
+        if (!Bonded.CONFIG.sendChatMessages.get()) {
+            return;
+        }
+
+        MutableComponent message = itemLevel == maxLevel
+                ? Component.translatable("bonded.gameplay.max_level", stack.getDisplayName().getString(), itemLevel)
+                : Component.translatable("bonded.gameplay.level_up", stack.getDisplayName().getString(), itemLevel);
+
+        player.displayClientMessage(
+                message.append(Component.literal(String.valueOf(itemLevel)).withStyle(ChatFormatting.GOLD)),
+                false
+        );
+    }
+
+    private static void emitProgressEvents(ItemStack item, Player player, int experienceAmount) {
+        if (item.isEmpty()) {
+            return;
+        }
+
+        ItemStack gear = Bonded.GEAR.initComponent(item);
+        var container = gear.get(DataComponents.ITEM_LEVEL_CONTAINER.get());
+        if (container == null) {
+            return;
+        }
+
+        InteractionResult result = BondEvent.ITEM_EXPERIENCE_GAINED.invoker()
+                .experience(gear, player, container, experienceAmount);
+        if (result != InteractionResult.PASS) {
+            return;
+        }
+
+        boolean hasLeveled = Bonded.GEAR.giveItemExperience(gear, experienceAmount);
+        ItemLevelContainer updatedContainer = gear.get(DataComponents.ITEM_LEVEL_CONTAINER.get());
+        if (updatedContainer != null) {
+            Bonded.GEAR.bondBonusRegistry.applyBonuses(gear, Bonded.GEAR.getLeveler(gear), updatedContainer);
+        }
+        if (player instanceof ServerPlayer serverPlayer) {
+            if (updatedContainer != null) {
+                BondedAdvancements.grantBondMilestones(serverPlayer, updatedContainer.getBond());
+            }
+        }
+        if (hasLeveled) {
+            BondEvent.ITEM_LEVELED_UP.invoker().level(gear, player, container, container.getLevel());
+        }
+    }
+
+    private static void onBlockBreak(Level level, BlockPos pos, BlockState state,
+            ServerPlayer player, BlockEntity blockEntity) {
+        var handItem = player.getMainHandItem();
+        if (handItem.isEmpty()) {
+            return;
+        }
+
+        var leveler = Bonded.GEAR.getLeveler(handItem);
+        if (leveler == null || !handItem.getItem().isCorrectToolForDrops(handItem, state)) {
+            return;
+        }
+
+        emitProgressEvents(handItem, player, getBlockBreakExperienceAmount(level, pos, player));
+    }
+
+    private static int getBlockBreakExperienceAmount(Level level, BlockPos pos, ServerPlayer player) {
+        var hasSilkTouch = ItemFunctions.containsEnchantment(
+                player.getMainHandItem(),
+                Identifier.fromNamespaceAndPath("minecraft", "silk_touch")
+        );
+        if (hasSilkTouch) {
+            return 1;
+        }
+
+        return Bonded.GEAR.getExperienceForBlock(level.getBlockState(pos).getBlock());
+    }
+
+    private static void onGenericItemExperience(Player player, ItemStack stack, int experienceAmount) {
+        if (Bonded.GEAR.getLeveler(stack) == null) {
+            return;
+        }
+
+        emitProgressEvents(stack, player, experienceAmount);
+    }
+
+    private static void onItemCrafted(ServerPlayer player, List<ItemStack> stacks) {
+        NonNullList<ItemStack> items = ItemFunctions.getInventoryItems(player.getInventory());
+        items.forEach(item -> Bonded.GEAR.initComponent(item));
+    }
+
+    private static void onItemSmithed(ItemStack stack, List<ItemStack> relevantItems) {
+        DataComponentType<ItemLevelContainer> component = DataComponents.ITEM_LEVEL_CONTAINER.get();
+        var container = stack.get(component);
+
+        boolean isNetheriteUpgrade = relevantItems.stream()
+                .anyMatch(stack1 -> stack1.is(Items.NETHERITE_UPGRADE_SMITHING_TEMPLATE));
+        boolean isCompat = relevantItems.stream()
+                .map(ItemStack::getItem)
+                .map(BuiltInRegistries.ITEM::getKey)
+                .anyMatch(id -> id != null && id.getPath().contains("upgrade_smithing_template"));
+
+        if (container != null && (isNetheriteUpgrade || isCompat)) {
+            stack.set(component,
+                    ItemLevelContainer.make(TierMap.getExperienceCap(stack.getItem()))
+                            .addBond(container.getBond()));
+        }
+    }
+
+    private static void onItemPickedUp(Player player, ItemEntity itemEntity, ItemStack stack) {
+        if (player instanceof ServerPlayer serverPlayer) {
+            ItemStack pickedUpStack = Bonded.GEAR.initComponent(stack);
+            ItemLevelContainer container = pickedUpStack.get(DataComponents.ITEM_LEVEL_CONTAINER.get());
+            if (container != null) {
+                BondedAdvancements.grantBondMilestones(serverPlayer, container.getBond());
+            }
+        }
+
+        NonNullList<ItemStack> items = ItemFunctions.getInventoryItems(player.getInventory());
+        for (var i = 0; i < items.size(); i++) {
+            if (i == player.getInventory().getSelectedSlot()) {
+                continue;
+            }
+            ItemStack item = player.getInventory().getItem(i);
+            if (!item.isEmpty()) {
+                Bonded.GEAR.initComponent(item);
+                if (player instanceof ServerPlayer serverPlayer) {
+                    ItemLevelContainer container = item.get(DataComponents.ITEM_LEVEL_CONTAINER.get());
+                    if (container != null) {
+                        BondedAdvancements.grantBondMilestones(serverPlayer, container.getBond());
+                    }
+                }
+            }
+        }
+    }
+
+    private static void onShieldBlock(Player player, ItemStack shield, float blockedDamage, DamageSource source) {
+        if (player instanceof ServerPlayer serverPlayer) {
+            emitProgressEvents(
+                    shield,
+                    serverPlayer,
+                    (int) ((blockedDamage + 1) * Bonded.CONFIG.armorDamageTakenExperienceGainedMultiplier.get())
+            );
+        }
+    }
+
+    private static void onEntityHurt(LivingEntity entity, DamageSource source, float baseDamageTaken,
+            float damageTaken, boolean blocked) {
+        var level = entity.level();
+        if (level.isClientSide()) {
+            return;
+        }
+
+        if (source.getEntity() instanceof Player player) {
+            processPlayerDealtDamage(player, source, damageTaken);
+        }
+        if (entity instanceof Player player) {
+            processPlayerTakenDamage(player, source, damageTaken);
+        }
+    }
+
+    private static void processPlayerDealtDamage(Player player, DamageSource source, float amount) {
+        ItemStack handItem = source.getWeaponItem();
+        if (handItem == null || handItem.isEmpty()) {
+            handItem = player.getWeaponItem();
+        }
+        if (handItem == null || handItem.isEmpty()) {
+            handItem = ItemUtils.checkForRocketCrossbow(player, source);
+        }
+        if (handItem == null || handItem.isEmpty()) {
+            return;
+        }
+
+        GearTypeLeveler leveler = Bonded.GEAR.getLeveler(handItem);
+        if (leveler instanceof MeleeWeaponsLeveler) {
+            emitProgressEvents(
+                    handItem,
+                    player,
+                    (int) (amount * Bonded.CONFIG.weaponDamageDealtExperienceGainedMultiplier.get())
+            );
+        }
+
+        boolean isRangedWeapon = handItem.getItem() instanceof ProjectileWeaponItem;
+        boolean isProjectile = source.getDirectEntity() instanceof Projectile;
+        if (isRangedWeapon && isProjectile) {
+            ItemStack foundBow = ItemUtils.tryToFindStack(player, handItem);
+            emitProgressEvents(
+                    foundBow,
+                    player,
+                    (int) (amount * Bonded.CONFIG.weaponDamageDealtExperienceGainedMultiplier.get())
+            );
+        }
+
+        for (var slot : ItemFunctions.getArmorSlots(player)) {
+            if (!Bonded.GEAR.isGear(slot)) {
+                continue;
+            }
+            emitProgressEvents(
+                    slot,
+                    player,
+                    (int) ((amount * Bonded.CONFIG.weaponDamageDealtExperienceGainedMultiplier.get()) + 1)
+            );
+        }
+    }
+
+    private static void processPlayerTakenDamage(Player player, DamageSource source, float amount) {
+        if (source.getEntity() == null) {
+            return;
+        }
+
+        for (var slot : ItemFunctions.getArmorSlots(player)) {
+            if (!Bonded.GEAR.isGear(slot)) {
+                continue;
+            }
+            emitProgressEvents(
+                    slot,
+                    player,
+                    Bonded.CONFIG.armorDamageTakenExperienceGainedMultiplier.get().intValue()
+            );
+        }
+    }
+
+    private static void onModifyDefaultComponents(ItemEvents.ComponentModificationContext context) {
+        TierMap.getRepairMaterialMap().forEach((item, material) -> context.modify(item, builder -> builder.set(
+                REPAIRABLE,
+                new Repairable(HolderSet.direct(material.builtInRegistryHolder()))
+        )));
+    }
+}

--- a/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/mixin/GuiGraphicsExtractorMixin.java
+++ b/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/mixin/GuiGraphicsExtractorMixin.java
@@ -1,0 +1,42 @@
+package com.iamkaf.bonded.mixin;
+
+import com.iamkaf.bonded.util.MaxDamageModifiers;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.util.ARGB;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GuiGraphics.class)
+public abstract class GuiGraphicsExtractorMixin {
+    private static final int BONDED_OVER_REPAIR_COLOR = ARGB.color(255, 255, 102, 221);
+    private static final int BAR_WIDTH = 13;
+
+    @Inject(method = "renderItemBar", at = @At("HEAD"), cancellable = true)
+    private void bonded$drawOverRepairBar(ItemStack itemStack, int x, int y, CallbackInfo ci) {
+        if (!itemStack.isBarVisible() || !itemStack.isDamaged() || !MaxDamageModifiers.hasOverRepair(itemStack)) {
+            return;
+        }
+
+        GuiGraphics graphics = (GuiGraphics) (Object) this;
+        int left = x + 2;
+        int top = y + 13;
+        graphics.fill(RenderPipelines.GUI, left, top, left + BAR_WIDTH, top + 2, -16777216);
+        graphics.fill(
+                RenderPipelines.GUI,
+                left,
+                top,
+                left + MaxDamageModifiers.getBaseDurabilityBarWidth(itemStack, BAR_WIDTH),
+                top + 1,
+                ARGB.opaque(MaxDamageModifiers.getBaseDurabilityBarColor(itemStack))
+        );
+        int pinkWidth = MaxDamageModifiers.getOverRepairBarWidth(itemStack, BAR_WIDTH);
+        if (pinkWidth > 0) {
+            graphics.fill(RenderPipelines.GUI, left, top, left + pinkWidth, top + 1, BONDED_OVER_REPAIR_COLOR);
+        }
+        ci.cancel();
+    }
+}

--- a/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/mixin/ItemMixin.java
+++ b/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/mixin/ItemMixin.java
@@ -1,0 +1,66 @@
+package com.iamkaf.bonded.mixin;
+
+import com.iamkaf.amber.api.functions.v1.ClientFunctions;
+import com.iamkaf.bonded.Bonded;
+import com.iamkaf.bonded.registry.DataComponents;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.component.TooltipDisplay;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * This mixin adds the item level info to the item's tooltip.
+ */
+@Mixin(Item.class)
+public abstract class ItemMixin {
+    @Inject(method = "appendHoverText(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/Item$TooltipContext;Lnet/minecraft/world/item/component/TooltipDisplay;Ljava/util/function/Consumer;Lnet/minecraft/world/item/TooltipFlag;)V", at = @At("HEAD"))
+    public void bonded$addItemLevelToTooltip(ItemStack stack, Item.TooltipContext context, TooltipDisplay tooltipDisplay,
+            Consumer<Component> tooltipAdder, TooltipFlag flag, CallbackInfo ci) {
+        if (!Bonded.CONFIG.enableTooltips.get()) {
+            return;
+        }
+        var levelingComponent = stack.get(DataComponents.ITEM_LEVEL_CONTAINER.get());
+
+        if (levelingComponent == null) {
+            return;
+        }
+
+        List<Component> tooltipComponents = new ArrayList<>();
+
+        tooltipComponents.add(Component.literal("Lv. " + levelingComponent.getLevel()).withStyle(ChatFormatting.YELLOW));
+        if (levelingComponent.getLevel() != Bonded.CONFIG.levelsToUpgrade.get()) {
+            tooltipComponents.add(Component.literal("Exp. " + levelingComponent.getExperience() + "/" + levelingComponent.getMaxExperience())
+                    .withStyle(ChatFormatting.GREEN));
+        } else {
+            tooltipComponents.add(Component.literal("Exp. MAX").withStyle(ChatFormatting.GREEN));
+        }
+
+        tooltipComponents.add(Component.literal("Bond " + levelingComponent.getBond() + "\ueef2")
+                .withStyle(ChatFormatting.RED));
+        tooltipComponents.forEach(tooltipAdder);
+
+        if (flag.isAdvanced()) {
+            var bonuses = stack.get(DataComponents.APPLIED_BONUSES_CONTAINER.get());
+            MutableComponent bonusesTooltip =
+                    Component.literal(String.format("Bonuses (%s):", bonuses == null ? 0 : bonuses.bonuses().size()));
+            ClientFunctions.SmartTooltip smartTooltip = new ClientFunctions.SmartTooltip().shift(bonusesTooltip);
+            if (bonuses != null) {
+                for (var bonus : bonuses.bonuses()) {
+                    smartTooltip.shift(Component.literal("- " + bonus.toString()));
+                }
+            }
+            smartTooltip.into(tooltipAdder);
+        }
+    }
+}

--- a/versions/1.21.11/fabric/src/main/java/com/iamkaf/bonded/BondedFabric.java
+++ b/versions/1.21.11/fabric/src/main/java/com/iamkaf/bonded/BondedFabric.java
@@ -1,0 +1,18 @@
+package com.iamkaf.bonded;
+
+import com.iamkaf.bonded.Bonded;
+import fuzs.forgeconfigapiport.fabric.api.v5.ConfigRegistry;
+import net.fabricmc.api.ModInitializer;
+import net.neoforged.fml.config.ModConfig;
+
+/**
+ * Fabric entry point.
+ */
+public class BondedFabric implements ModInitializer {
+
+    @Override
+    public void onInitialize() {
+        ConfigRegistry.INSTANCE.register(Bonded.MOD_ID, ModConfig.Type.COMMON, Bonded.CONFIG_SPEC);
+        Bonded.init();
+    }
+}

--- a/versions/1.21.11/fabric/src/main/java/com/iamkaf/bonded/fabric/BondedFabricClient.java
+++ b/versions/1.21.11/fabric/src/main/java/com/iamkaf/bonded/fabric/BondedFabricClient.java
@@ -1,0 +1,11 @@
+package com.iamkaf.bonded.fabric;
+
+import com.iamkaf.bonded.BondedClient;
+import net.fabricmc.api.ClientModInitializer;
+
+public final class BondedFabricClient implements ClientModInitializer {
+    @Override
+    public void onInitializeClient() {
+        BondedClient.init();
+    }
+}

--- a/versions/1.21.11/fabric/src/main/resources/fabric.mod.json
+++ b/versions/1.21.11/fabric/src/main/resources/fabric.mod.json
@@ -1,0 +1,44 @@
+{
+    "schemaVersion": 1,
+    "id": "${mod_id}",
+    "version": "${version}",
+    "name": "${mod_name}",
+    "description": "${description}",
+    "authors": [
+        "${mod_author}"
+    ],
+    "contact": {
+        "homepage": "https://github.com/iamkaf/bonded",
+        "issues": "https://github.com/iamkaf/bonded/issues",
+        "sources": "https://github.com/iamkaf/bonded"
+    },
+    "license": "${license}",
+    "icon": "assets/${mod_id}/icon.png",
+    "environment": "*",
+    "entrypoints": {
+        "main": [
+            "com.iamkaf.bonded.BondedFabric"
+        ],
+        "client": [
+            "com.iamkaf.bonded.fabric.BondedFabricClient"
+        ],
+        "fabric-datagen": [
+            "com.iamkaf.bonded.fabric.BondedDatagen"
+        ]
+    },
+    "mixins": [
+        "${mod_id}.mixins.json",
+        "${mod_id}.fabric.mixins.json"
+    ],
+    "depends": {
+        "fabricloader": "*",
+        "fabric-api": "*",
+        "minecraft": "${fabric_version_range}",
+        "java": ">=${java_version}",
+        "amber": ">=${amber_version}",
+        "forgeconfigapiport": "*"
+    },
+    "suggests": {
+        "modmenu": ">=${mod_menu_version}"
+    }
+}

--- a/versions/1.21.11/forge/src/main/java/com/iamkaf/bonded/BondedForge.java
+++ b/versions/1.21.11/forge/src/main/java/com/iamkaf/bonded/BondedForge.java
@@ -1,0 +1,24 @@
+package com.iamkaf.bonded;
+
+import com.iamkaf.bonded.Bonded;
+import fuzs.forgeconfigapiport.forge.api.v5.NeoForgeConfigRegistry;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
+
+@Mod(Bonded.MOD_ID)
+public class BondedForge {
+
+    public BondedForge() {
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            BondedClient.init();
+        }
+
+        // Register config using FCAP API
+        NeoForgeConfigRegistry.INSTANCE.register(Bonded.MOD_ID, ModConfig.Type.COMMON, Bonded.CONFIG_SPEC);
+
+        // Initialize mod
+        Bonded.init();
+    }
+}

--- a/versions/1.21.11/forge/src/main/java/com/iamkaf/bonded/platform/ForgePlatformHelper.java
+++ b/versions/1.21.11/forge/src/main/java/com/iamkaf/bonded/platform/ForgePlatformHelper.java
@@ -1,0 +1,33 @@
+package com.iamkaf.bonded.platform;
+
+import com.iamkaf.bonded.platform.services.IPlatformHelper;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.loading.FMLLoader;
+import net.minecraftforge.fml.loading.FMLPaths;
+import java.nio.file.Path;
+
+public class ForgePlatformHelper implements IPlatformHelper {
+
+    @Override
+    public String getPlatformName() {
+
+        return "Forge";
+    }
+
+    @Override
+    public boolean isModLoaded(String modId) {
+
+        return ModList.get().isLoaded(modId);
+    }
+
+    @Override
+    public boolean isDevelopmentEnvironment() {
+
+        return !FMLLoader.isProduction();
+    }
+
+    @Override
+    public Path getConfigDirectory() {
+        return FMLPaths.CONFIGDIR.get();
+    }
+}

--- a/versions/1.21.11/forge/src/main/resources/META-INF/mods.toml
+++ b/versions/1.21.11/forge/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,41 @@
+modLoader = "javafml" #mandatory
+loaderVersion = "${forge_loader_version_range}" #mandatory
+license = "${license}" #mandatory
+issueTrackerURL="https://github.com/iamkaf/bonded/issues" #optional
+#clientSideOnly=true #optional
+
+[[mods]] #mandatory
+modId = "${mod_id}" #mandatory
+version = "${version}" #mandatory
+displayName = "${mod_name}" #mandatory
+credits = "${credits}" #optional
+authors = "${mod_author}" #optional
+description = '''${description}''' #mandatory
+
+[[dependencies.${mod_id}]]
+modId = "forge"
+mandatory = true
+versionRange = "[${forge_version},)"
+ordering = "NONE"
+side = "BOTH"
+
+[[dependencies.${mod_id}]]
+modId = "minecraft"
+mandatory = true
+versionRange = "${minecraft_version_range}"
+ordering = "NONE"
+side = "BOTH"
+
+[[dependencies.${mod_id}]]
+modId = "amber"
+mandatory = true
+versionRange = "[${amber_version},)"
+ordering = "BEFORE"
+side = "BOTH"
+
+[[dependencies.${mod_id}]]
+modId = "forgeconfigapiport"
+mandatory = true
+versionRange = "*"
+ordering = "BEFORE"
+side = "BOTH"

--- a/versions/1.21.11/gradle.properties
+++ b/versions/1.21.11/gradle.properties
@@ -1,0 +1,14 @@
+project.version=3.1.1+1.21.11
+project.java=21
+project.build-java=21
+project.minecraft=1.21.11
+project.enabled-loaders=fabric,forge,neoforge
+
+mod.minecraft-range=[1.21.11, 1.22)
+mod.fabric-range=>=1.21.11
+mod.forge-loader-range=[61,)
+mod.neoforge-loader-range=[4,)
+
+publish.game-versions=1.21.11
+dependencies.modrinth.required=amber,forge-config-api-port
+dependencies.curseforge.required=amber-lib,forge-config-api-port

--- a/versions/1.21.11/neoforge/src/main/java/com/iamkaf/bonded/BondedNeoForge.java
+++ b/versions/1.21.11/neoforge/src/main/java/com/iamkaf/bonded/BondedNeoForge.java
@@ -1,0 +1,16 @@
+package com.iamkaf.bonded;
+
+import com.iamkaf.bonded.Bonded;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.config.ModConfig;
+
+@Mod(Bonded.MOD_ID)
+public final class BondedNeoForge {
+    public BondedNeoForge(IEventBus eBussy, ModContainer container) {
+        // Run our common setup.
+        Bonded.init();
+        container.registerConfig(ModConfig.Type.COMMON, Bonded.CONFIG_SPEC);
+    }
+}

--- a/versions/1.21.11/neoforge/src/main/java/com/iamkaf/bonded/neoforge/client/BondedNeoForgeClient.java
+++ b/versions/1.21.11/neoforge/src/main/java/com/iamkaf/bonded/neoforge/client/BondedNeoForgeClient.java
@@ -1,0 +1,17 @@
+package com.iamkaf.bonded.neoforge.client;
+
+import com.iamkaf.bonded.Bonded;
+import com.iamkaf.bonded.BondedClient;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.client.gui.ConfigurationScreen;
+import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
+
+@Mod(value = Bonded.MOD_ID, dist = Dist.CLIENT)
+public class BondedNeoForgeClient {
+    public BondedNeoForgeClient(ModContainer container) {
+        container.registerExtensionPoint(IConfigScreenFactory.class, ConfigurationScreen::new);
+        BondedClient.init();
+    }
+}

--- a/versions/1.21.11/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/versions/1.21.11/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,0 +1,40 @@
+modLoader = "javafml"
+loaderVersion = "${neoforge_loader_version_range}"
+license = "${license}"
+issueTrackerURL = "https://github.com/iamkaf/bonded/issues"
+
+[[mods]]
+modId = "${mod_id}"
+version = "${version}"
+displayName = "${mod_name}"
+authors = "${mod_author}"
+credits = "${credits}"
+description = '''${description}'''
+logoFile = "assets/${mod_id}/icon.png"
+
+[[dependencies.${mod_id}]]
+modId = "neoforge"
+type = "required"
+versionRange = "[${neoforge_version},)"
+ordering = "NONE"
+side = "BOTH"
+
+[[dependencies.${mod_id}]]
+modId = "minecraft"
+type = "required"
+versionRange = "${minecraft_version_range}"
+ordering = "NONE"
+side = "BOTH"
+
+[[dependencies.${mod_id}]]
+modId = "amber"
+type = "required"
+versionRange = "[${amber_version},)"
+ordering = "BEFORE"
+side = "BOTH"
+
+[[mixins]]
+config = "${mod_id}.mixins.json"
+
+[[mixins]]
+config = "${mod_id}.neoforge.mixins.json"

--- a/versions/26.1.2/gradle.properties
+++ b/versions/26.1.2/gradle.properties
@@ -1,4 +1,4 @@
-project.version=3.1.0+26.1.2
+project.version=3.1.1+26.1.2
 project.java=25
 project.build-java=25
 project.minecraft=26.1.2

--- a/versions/26.2/gradle.properties
+++ b/versions/26.2/gradle.properties
@@ -1,4 +1,4 @@
-project.version=4.0.0+26.2
+project.version=4.0.1+26.2
 project.java=25
 project.build-java=25
 project.minecraft=26.2


### PR DESCRIPTION
Prevents non-damageable body armor, such as horse armor, from being treated as Bonded armor if it appears in the armor tag through a datapack or tag change.

This keeps damageable body armor, such as wolf armor, eligible while filtering unsupported armor during gear registry loading and lookup. It also strips stale Bonded max-damage modifier data when an item no longer has valid durability, avoiding invalid max-damage state from being preserved.

I checked this with the full TeaKit scenario matrix across Fabric, Forge, and NeoForge for both supported Minecraft lines. The new storage scenario covers golden horse armor, iron horse armor, and wolf armor, and `just build-all` passes.

Also backported v3 to 1.21.11.