### PR TITLE
Fix ore experience and remote HUD lookup

### DIFF
--- a/common/src/main/java/com/iamkaf/bonded/leveling/GameplayHooks.java
+++ b/common/src/main/java/com/iamkaf/bonded/leveling/GameplayHooks.java
@@ -134,10 +134,10 @@ public class GameplayHooks {
             return;
         }
 
-        emitProgressEvents(handItem, player, getBlockBreakExperienceAmount(level, pos, player));
+        emitProgressEvents(handItem, player, getBlockBreakExperienceAmount(state, player));
     }
 
-    private static int getBlockBreakExperienceAmount(Level level, BlockPos pos, ServerPlayer player) {
+    private static int getBlockBreakExperienceAmount(BlockState state, ServerPlayer player) {
         var hasSilkTouch = ItemFunctions.containsEnchantment(
                 player.getMainHandItem(),
                 Identifier.fromNamespaceAndPath("minecraft", "silk_touch")
@@ -146,7 +146,7 @@ public class GameplayHooks {
             return 1;
         }
 
-        return Bonded.GEAR.getExperienceForBlock(level.getBlockState(pos).getBlock());
+        return Bonded.GEAR.getExperienceForBlock(state.getBlock());
     }
 
     private static void onGenericItemExperience(Player player, ItemStack stack, int experienceAmount) {

--- a/common/src/main/java/com/iamkaf/bonded/registry/GearTypeLevelerRegistry.java
+++ b/common/src/main/java/com/iamkaf/bonded/registry/GearTypeLevelerRegistry.java
@@ -22,11 +22,15 @@ public class GearTypeLevelerRegistry {
         }
 
         GearTypeLeveler leveler = map.get(BuiltInRegistries.ITEM.getKey(gear.getItem()));
-        if (leveler == null || !leveler.supports(gear)) {
-            return null;
+        if (leveler != null) {
+            return leveler.supports(gear) ? leveler : null;
         }
 
-        return leveler;
+        return levelers.stream()
+                .filter(candidate -> gear.getItem().builtInRegistryHolder().is(candidate.tag()))
+                .filter(candidate -> candidate.supports(gear))
+                .findFirst()
+                .orElse(null);
     }
 
     public GearTypeLeveler register(GearTypeLeveler leveler) {

--- a/test/scenarios/bonded/ore-experience.scenario.ts
+++ b/test/scenarios/bonded/ore-experience.scenario.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "@teakit/test";
+import type { ScenarioDefinition } from "@teakit/test";
+
+const oreExperienceScenario: ScenarioDefinition = {
+  name: "bonded-ore-experience",
+  setup: [
+    { action: "command", command: "/clear @s" },
+    { action: "command", command: "/gamemode survival @s" },
+    { action: "command", command: "/tp @s 0 72 -1" },
+    { action: "command", command: "/fill -2 70 -2 2 74 2 minecraft:air replace" },
+    { action: "command", command: "/fill -2 70 -2 2 70 2 minecraft:stone replace" },
+    { action: "command", command: "/setblock 0 71 0 minecraft:iron_ore" },
+    {
+      action: "wait_for_block",
+      x: 0,
+      y: 71,
+      z: 0,
+      blockId: "minecraft:iron_ore",
+      timeoutMs: 3000
+    }
+  ],
+  steps: [
+    {
+      action: "command",
+      command: "/item replace entity @s weapon.mainhand with minecraft:iron_pickaxe[bonded:item_level={experience:0,maxExperience:1000,level:1,bond:0}]"
+    },
+    {
+      action: "break_block",
+      x: 0,
+      y: 71,
+      z: 0,
+      direction: "up",
+      timeoutMs: 5000
+    },
+    {
+      action: "assert_command_success",
+      command: "/data get entity @s SelectedItem.components.\"bonded:item_level\".experience",
+      expectOutputContains: ["10"]
+    }
+  ],
+  cleanup: [
+    { action: "command", command: "/clear @s" },
+    { action: "command", command: "/gamemode creative @s" },
+    { action: "command", command: "/fill -2 70 -2 2 74 2 minecraft:air replace" }
+  ]
+};
+
+describe("Bonded ore experience", () => {
+  test(oreExperienceScenario.name, async ({ scenario }) => {
+    const result = await scenario.run(oreExperienceScenario, { timeoutMs: 60_000 });
+
+    expect(result.error ?? null).toBeNull();
+  });
+});

--- a/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/leveling/GameplayHooks.java
+++ b/versions/1.21.11/common/src/main/java/com/iamkaf/bonded/leveling/GameplayHooks.java
@@ -135,10 +135,10 @@ public class GameplayHooks {
             return;
         }
 
-        emitProgressEvents(handItem, player, getBlockBreakExperienceAmount(level, pos, player));
+        emitProgressEvents(handItem, player, getBlockBreakExperienceAmount(state, player));
     }
 
-    private static int getBlockBreakExperienceAmount(Level level, BlockPos pos, ServerPlayer player) {
+    private static int getBlockBreakExperienceAmount(BlockState state, ServerPlayer player) {
         var hasSilkTouch = ItemFunctions.containsEnchantment(
                 player.getMainHandItem(),
                 Identifier.fromNamespaceAndPath("minecraft", "silk_touch")
@@ -147,7 +147,7 @@ public class GameplayHooks {
             return 1;
         }
 
-        return Bonded.GEAR.getExperienceForBlock(level.getBlockState(pos).getBlock());
+        return Bonded.GEAR.getExperienceForBlock(state.getBlock());
     }
 
     private static void onGenericItemExperience(Player player, ItemStack stack, int experienceAmount) {

--- a/versions/26.1.1/common/src/main/java/com/iamkaf/bonded/leveling/GameplayHooks.java
+++ b/versions/26.1.1/common/src/main/java/com/iamkaf/bonded/leveling/GameplayHooks.java
@@ -134,10 +134,10 @@ public class GameplayHooks {
             return;
         }
 
-        emitProgressEvents(handItem, player, getBlockBreakExperienceAmount(level, pos, player));
+        emitProgressEvents(handItem, player, getBlockBreakExperienceAmount(state, player));
     }
 
-    private static int getBlockBreakExperienceAmount(Level level, BlockPos pos, ServerPlayer player) {
+    private static int getBlockBreakExperienceAmount(BlockState state, ServerPlayer player) {
         var hasSilkTouch = ItemFunctions.containsEnchantment(
                 player.getMainHandItem(),
                 Identifier.fromNamespaceAndPath("minecraft", "silk_touch")
@@ -146,7 +146,7 @@ public class GameplayHooks {
             return 1;
         }
 
-        return Bonded.GEAR.getExperienceForBlock(level.getBlockState(pos).getBlock());
+        return Bonded.GEAR.getExperienceForBlock(state.getBlock());
     }
 
     private static void onGenericItemExperience(Player player, ItemStack stack, int experienceAmount) {

--- a/versions/26.1.2/common/src/main/java/com/iamkaf/bonded/leveling/GameplayHooks.java
+++ b/versions/26.1.2/common/src/main/java/com/iamkaf/bonded/leveling/GameplayHooks.java
@@ -134,10 +134,10 @@ public class GameplayHooks {
             return;
         }
 
-        emitProgressEvents(handItem, player, getBlockBreakExperienceAmount(level, pos, player));
+        emitProgressEvents(handItem, player, getBlockBreakExperienceAmount(state, player));
     }
 
-    private static int getBlockBreakExperienceAmount(Level level, BlockPos pos, ServerPlayer player) {
+    private static int getBlockBreakExperienceAmount(BlockState state, ServerPlayer player) {
         var hasSilkTouch = ItemFunctions.containsEnchantment(
                 player.getMainHandItem(),
                 Identifier.fromNamespaceAndPath("minecraft", "silk_touch")
@@ -146,7 +146,7 @@ public class GameplayHooks {
             return 1;
         }
 
-        return Bonded.GEAR.getExperienceForBlock(level.getBlockState(pos).getBlock());
+        return Bonded.GEAR.getExperienceForBlock(state.getBlock());
     }
 
     private static void onGenericItemExperience(Player player, ItemStack stack, int experienceAmount) {

--- a/versions/26.1/common/src/main/java/com/iamkaf/bonded/leveling/GameplayHooks.java
+++ b/versions/26.1/common/src/main/java/com/iamkaf/bonded/leveling/GameplayHooks.java
@@ -134,10 +134,10 @@ public class GameplayHooks {
             return;
         }
 
-        emitProgressEvents(handItem, player, getBlockBreakExperienceAmount(level, pos, player));
+        emitProgressEvents(handItem, player, getBlockBreakExperienceAmount(state, player));
     }
 
-    private static int getBlockBreakExperienceAmount(Level level, BlockPos pos, ServerPlayer player) {
+    private static int getBlockBreakExperienceAmount(BlockState state, ServerPlayer player) {
         var hasSilkTouch = ItemFunctions.containsEnchantment(
                 player.getMainHandItem(),
                 Identifier.fromNamespaceAndPath("minecraft", "silk_touch")
@@ -146,7 +146,7 @@ public class GameplayHooks {
             return 1;
         }
 
-        return Bonded.GEAR.getExperienceForBlock(level.getBlockState(pos).getBlock());
+        return Bonded.GEAR.getExperienceForBlock(state.getBlock());
     }
 
     private static void onGenericItemExperience(Player player, ItemStack stack, int experienceAmount) {


### PR DESCRIPTION
Ore mining now awards experience from the block state captured by the break event, so ores receive the configured 10 XP instead of falling back to the 1 XP default after the block has become air.

Bench HUD gear detection now falls back to synced item tags when the client-side lookup cache has not been populated by an integrated server. This makes the HUD reliable when connecting directly to multiplayer servers.

A runtime scenario covers the ore experience regression across supported loaders.